### PR TITLE
Bug Fixes

### DIFF
--- a/run
+++ b/run
@@ -9,7 +9,7 @@ case "$1" in
   test)
     # Run Test Cases
     echo "Test Cases"
-    python3 ./test.py
+    python3 ./run.py test
     ;;
 
   -h | --help)
@@ -19,7 +19,7 @@ positional arguments:
   install             Install any dependencies needed
   test                Runs testing suite
   URL_FILE            Absolute file location of set of URLs
-              
+
   options:
   -h, --help          show this help message
   -v. --verbose       enable verbose output

--- a/url_class.py
+++ b/url_class.py
@@ -68,7 +68,7 @@ def parse_hf_dataset_url_repo(url: str) -> str:
 
     return parts[-1]   # last segment is always the repo
 
-def parse_project_file(filepath: str | Path) -> List[ProjectGroup]:
+def parse_project_file(filepath: str) -> List[ProjectGroup]:
     """
     Parse a text file where each line has format:
         code_link,dataset_link,model_link


### PR DESCRIPTION
Moved the endpoint of `./run test` to `./run.py`.
Typing fix for url_class.py function parse_project_file